### PR TITLE
Update activeCode_selectq.rst

### DIFF
--- a/_sources/Chapter2/activeCode_selectq.rst
+++ b/_sources/Chapter2/activeCode_selectq.rst
@@ -81,7 +81,7 @@ Answer the following **Activecode** questions to assess what you have learned in
             volume = 
 
             // DO NOT MODIFY ANYTHING BELOW THIS LINE.
-            cout << "Your solution had volume = " << volume << endl;  cout << "The correct solution has volume = 104.667";
+            cout << "Your solution had volume = " << volume << endl;  cout << "The correct solution has volume = 523.333";
          }
 
    .. tab:: Parsonsprob


### PR DESCRIPTION
Corrected the answer to exercise 3 - the correct volume of a sphere of radius 5, calculated with pi = 3.14 is 523.333, not 104.667.