### PR TITLE
Add document-id and edition to docinfo

### DIFF
--- a/pretext/main.ptx
+++ b/pretext/main.ptx
@@ -3,6 +3,7 @@
          xml:lang="en-US">
 
   <docinfo>
+    <document-id edition="ptx">thinkcpp</document-id>
     <numbering>
       <figures level="2"/>
       <exercises level="2"/>


### PR DESCRIPTION
docinfo needs a document-id and edition to make correctly unique identifiers for questions.

I have no actual preference for the values used for the id/edition, these are merely suggestions.